### PR TITLE
Add Devnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # solana-kit-android
-Pure Kotlin Solana kit. Uses metaplex-foundation/SolanaKT. Syncs solana wallet and provides structured data.
+Pure Kotlin Solana kit. Uses metaplex-foundation/SolanaKT. Syncs Solana wallet and provides structured data.
+
+## Features
+
+- Mainnet and Devnet RPC endpoints

--- a/app/src/main/java/io/horizontalsystems/solanakit/sample/Configuration.kt
+++ b/app/src/main/java/io/horizontalsystems/solanakit/sample/Configuration.kt
@@ -3,6 +3,7 @@ package io.horizontalsystems.solanakit.sample
 import io.horizontalsystems.solanakit.models.RpcSource
 
 object Configuration {
+    // Use `RpcSource.Devnet` for devnet testing
     val rpcSource: RpcSource = RpcSource.TritonOne
     const val solscanApiKey: String = ""
     const val walletId = "walletId"

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
@@ -269,7 +269,7 @@ class SolanaKit(
             val transactionStorage = TransactionStorage(transactionDatabase, addressString)
             val solscanClient = SolscanClient(solscanApiKey, debug)
             val tokenAccountManager = TokenAccountManager(addressString, rpcApiClient, transactionStorage, mainStorage, SolanaFmService())
-            val transactionManager = TransactionManager(address, transactionStorage, rpcAction, tokenAccountManager)
+            val transactionManager = TransactionManager(address, transactionStorage, rpcAction, tokenAccountManager, rpcSource.endpoint.network)
             val pendingTransactionSyncer = PendingTransactionSyncer(rpcApiClient, transactionStorage, transactionManager)
             val transactionSyncer = TransactionSyncer(
                 address.publicKey,

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/models/RpcSource.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/models/RpcSource.kt
@@ -9,5 +9,6 @@ sealed class RpcSource(var name: String, var endpoint: RPCEndpoint, val syncInte
 
     object Serum: RpcSource("Serum Project API", RPCEndpoint.mainnetBetaSerum, 30)
     object TritonOne: RpcSource("TritonOne API", RPCEndpoint.mainnetBetaSolana, 30)
+    object Devnet: RpcSource("Solana Devnet", RPCEndpoint.devnetSolana, 30)
     class Custom(name: String, httpURL: URL, websocketURL: URL, syncInterval: Long): RpcSource(name, RPCEndpoint.custom(httpURL, websocketURL, Network.mainnetBeta), syncInterval)
 }

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionManager.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/TransactionManager.kt
@@ -13,6 +13,7 @@ import io.horizontalsystems.solanakit.models.FullTransaction
 import io.horizontalsystems.solanakit.models.TokenAccount
 import io.horizontalsystems.solanakit.models.TokenTransfer
 import io.horizontalsystems.solanakit.models.Transaction
+import com.solana.networking.Network
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -29,7 +30,8 @@ class TransactionManager(
     private val address: Address,
     private val storage: TransactionStorage,
     private val rpcAction: Action,
-    private val tokenAccountManager: TokenAccountManager
+    private val tokenAccountManager: TokenAccountManager,
+    private val network: Network
 ) {
 
     private val addressString = address.publicKey.toBase58()
@@ -129,7 +131,12 @@ class TransactionManager(
         }
 
     suspend fun sendSol(toAddress: Address, amount: Long, signerAccount: Account): FullTransaction {
-        val connection = Connection(RpcUrl.MAINNNET)
+        val rpcUrl = when (network) {
+            Network.mainnetBeta -> RpcUrl.MAINNNET
+            Network.devnet -> RpcUrl.DEVNET
+            Network.testnet -> RpcUrl.TESTNET
+        }
+        val connection = Connection(rpcUrl)
         val blockHash = connection.getLatestBlockhashExtended(Commitment.FINALIZED)
         val (transactionHash, base64Encoded) = rpcAction.sendSOL(
             account = signerAccount,
@@ -174,7 +181,12 @@ class TransactionManager(
         val tokenAccount = fullTokenAccount.tokenAccount
         val mintAccount = fullTokenAccount.mintAccount
 
-        val connection = Connection(RpcUrl.MAINNNET)
+        val rpcUrl = when (network) {
+            Network.mainnetBeta -> RpcUrl.MAINNNET
+            Network.devnet -> RpcUrl.DEVNET
+            Network.testnet -> RpcUrl.TESTNET
+        }
+        val connection = Connection(rpcUrl)
         val blockHash = connection.getLatestBlockhashExtended(Commitment.FINALIZED)
 
         val (transactionHash, base64Trx) = rpcAction.sendSPLTokens(


### PR DESCRIPTION
## Summary
- add devnet endpoint option
- make TransactionManager use network's RpcUrl
- expose network when creating TransactionManager
- document devnet usage

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_b_6859d15a7da083258f9011794c9df8c7