### PR TITLE
Handle pending transactions per network

### DIFF
--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
@@ -270,7 +270,12 @@ class SolanaKit(
             val solscanClient = SolscanClient(solscanApiKey, debug)
             val tokenAccountManager = TokenAccountManager(addressString, rpcApiClient, transactionStorage, mainStorage, SolanaFmService())
             val transactionManager = TransactionManager(address, transactionStorage, rpcAction, tokenAccountManager, rpcSource.endpoint.network)
-            val pendingTransactionSyncer = PendingTransactionSyncer(rpcApiClient, transactionStorage, transactionManager)
+            val pendingTransactionSyncer = PendingTransactionSyncer(
+                rpcApiClient,
+                transactionStorage,
+                transactionManager,
+                rpcSource.endpoint.network
+            )
             val transactionSyncer = TransactionSyncer(
                 address.publicKey,
                 rpcApiClient,

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/PendingTransactionSyncer.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/PendingTransactionSyncer.kt
@@ -1,6 +1,7 @@
 package io.horizontalsystems.solanakit.transactions
 
 import com.solana.api.Api
+import com.solana.networking.Network
 import com.solana.rxsolana.api.getBlockHeight
 import com.solana.rxsolana.api.getConfirmedTransaction
 import io.horizontalsystems.solanakit.database.transaction.TransactionStorage
@@ -17,7 +18,8 @@ import java.util.logging.Logger
 class PendingTransactionSyncer(
     private val rpcClient: Api,
     private val storage: TransactionStorage,
-    private val transactionManager: TransactionManager
+    private val transactionManager: TransactionManager,
+    private val network: Network
 ) {
     private val logger = Logger.getLogger("PendingTransactionSyncer")
 
@@ -66,7 +68,12 @@ class PendingTransactionSyncer(
 
     private fun sendTransaction(encodedTransaction: String) {
         try {
-            val connection = URL(RpcUrl.MAINNNET.value).openConnection() as HttpURLConnection
+            val rpcUrl = when (network) {
+                Network.mainnetBeta -> RpcUrl.MAINNNET
+                Network.devnet -> RpcUrl.DEVNET
+                Network.testnet -> RpcUrl.TESTNET
+            }
+            val connection = URL(rpcUrl.value).openConnection() as HttpURLConnection
             connection.requestMethod = "POST"
             connection.setRequestProperty("Content-Type", "application/json")
             connection.doOutput = true


### PR DESCRIPTION
## Summary
- pass the network into `PendingTransactionSyncer`
- resend pending transactions to the correct RPC URL
- forward the network from `SolanaKit.getInstance`

## Testing
- `./gradlew :solanakit:test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b2bfa0e0083258b659cff7e29aecd