### PR TITLE
Add cluster-aware Solscan client

### DIFF
--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
@@ -267,7 +267,7 @@ class SolanaKit(
 
             val transactionDatabase = SolanaDatabaseManager.getTransactionDatabase(application, walletId)
             val transactionStorage = TransactionStorage(transactionDatabase, addressString)
-            val solscanClient = SolscanClient(solscanApiKey, debug)
+            val solscanClient = SolscanClient(solscanApiKey, debug, rpcSource.endpoint.network)
             val tokenAccountManager = TokenAccountManager(addressString, rpcApiClient, transactionStorage, mainStorage, SolanaFmService())
             val transactionManager = TransactionManager(address, transactionStorage, rpcAction, tokenAccountManager, rpcSource.endpoint.network)
             val pendingTransactionSyncer = PendingTransactionSyncer(

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/SolscanClient.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/SolscanClient.kt
@@ -5,6 +5,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.ResponseBody
 import okhttp3.logging.HttpLoggingInterceptor
+import com.solana.networking.Network
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.IOException
@@ -15,10 +16,17 @@ import kotlin.coroutines.suspendCoroutine
 
 class SolscanClient(
     auth: String,
-    debug: Boolean
+    debug: Boolean,
+    network: Network
 ) {
-    val solSyncSourceName = "solscan.io/solTransfers"
-    val splSyncSourceName = "solscan.io/splTransfers"
+    private val clusterParam = when (network) {
+        Network.mainnetBeta -> ""
+        Network.devnet -> "&cluster=devnet"
+        Network.testnet -> "&cluster=testnet"
+    }
+
+    val solSyncSourceName = "solscan.io/solTransfers-${network.name}"
+    val splSyncSourceName = "solscan.io/splTransfers-${network.name}"
     private val url = "https://public-api.solscan.io"
 
     private val httpClient = httpClient(auth, debug)
@@ -68,7 +76,7 @@ class SolscanClient(
     }
 
     private suspend fun solTransfersChunk(account: String, limit: Int, page: Int): List<SolscanTransaction> {
-        val path = "/account/solTransfers?account=$account&limit=$limit&offset=${limit * page}"
+        val path = "/account/solTransfers?account=$account&limit=$limit&offset=${limit * page}$clusterParam"
         val request: Request = Request.Builder().url(url + path).build()
 
         return suspendCoroutine { continuation ->
@@ -100,7 +108,7 @@ class SolscanClient(
     }
 
     private suspend fun splTransfersChunk(account: String, limit: Int, page: Int): List<SolscanTransaction> {
-        val path = "/account/splTransfers?account=$account&limit=$limit&offset=${limit * page}"
+        val path = "/account/splTransfers?account=$account&limit=$limit&offset=${limit * page}$clusterParam"
         val request: Request = Request.Builder().url(url + path).build()
 
         return suspendCoroutine { continuation ->


### PR DESCRIPTION
## Summary
- extend `SolscanClient` to accept network parameter
- include network when constructing sync source names
- append network cluster query parameter when requesting transfers
- forward RPC network to `SolscanClient`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685dc24b948c8325a41d56dc9aa4d93a