### PR TITLE
Update Solscan sync source names with network

### DIFF
--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/SolscanClient.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/transactions/SolscanClient.kt
@@ -25,8 +25,8 @@ class SolscanClient(
         Network.testnet -> "&cluster=testnet"
     }
 
-    val solSyncSourceName = "solscan.io/solTransfers-${network.name}"
-    val splSyncSourceName = "solscan.io/splTransfers-${network.name}"
+    val solSyncSourceName = "solscan.io/${network.name}/solTransfers"
+    val splSyncSourceName = "solscan.io/${network.name}/splTransfers"
     private val url = "https://public-api.solscan.io"
 
     private val httpClient = httpClient(auth, debug)


### PR DESCRIPTION
## Summary
- parameterize Solscan sync source names by network name

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685dc69a3f9c8325b7670ee1c2d4fcf5