### PR TITLE
Pass network to SolscanClient

### DIFF
--- a/app/src/main/java/io/horizontalsystems/solanakit/sample/Configuration.kt
+++ b/app/src/main/java/io/horizontalsystems/solanakit/sample/Configuration.kt
@@ -1,10 +1,12 @@
 package io.horizontalsystems.solanakit.sample
 
 import io.horizontalsystems.solanakit.models.RpcSource
+import com.solana.networking.Network
 
 object Configuration {
     // Use `RpcSource.Devnet` for devnet testing
     val rpcSource: RpcSource = RpcSource.TritonOne
+    val network: Network = rpcSource.endpoint.network
     const val solscanApiKey: String = ""
     const val walletId = "walletId"
     const val defaultsWords = ""

--- a/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
+++ b/solanakit/src/main/java/io/horizontalsystems/solanakit/SolanaKit.kt
@@ -267,7 +267,9 @@ class SolanaKit(
 
             val transactionDatabase = SolanaDatabaseManager.getTransactionDatabase(application, walletId)
             val transactionStorage = TransactionStorage(transactionDatabase, addressString)
-            val solscanClient = SolscanClient(solscanApiKey, debug, rpcSource.endpoint.network)
+
+            val network = rpcSource.endpoint.network
+            val solscanClient = SolscanClient(solscanApiKey, debug, network)
             val tokenAccountManager = TokenAccountManager(addressString, rpcApiClient, transactionStorage, mainStorage, SolanaFmService())
             val transactionManager = TransactionManager(address, transactionStorage, rpcAction, tokenAccountManager, rpcSource.endpoint.network)
             val pendingTransactionSyncer = PendingTransactionSyncer(


### PR DESCRIPTION
## Summary
- forward network info when creating `SolscanClient`
- expose rpc network in the sample configuration

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685dce40fca483258f16b0b2460b9b9b