### PR TITLE
Set Devnet defaults and key placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Pure Kotlin Solana kit. Uses metaplex-foundation/SolanaKT. Syncs Solana wallet a
 
 - Mainnet and Devnet RPC endpoints
 
+`Configuration.kt` defaults to the Devnet RPC source. Edit `rpcSource` in that file to switch to mainnet.
+
 ## Initialization (Devnet)
 
 ```kotlin

--- a/app/src/main/java/io/horizontalsystems/solanakit/sample/Configuration.kt
+++ b/app/src/main/java/io/horizontalsystems/solanakit/sample/Configuration.kt
@@ -4,10 +4,13 @@ import io.horizontalsystems.solanakit.models.RpcSource
 import com.solana.networking.Network
 
 object Configuration {
-    // Use `RpcSource.Devnet` for devnet testing
-    val rpcSource: RpcSource = RpcSource.TritonOne
+    // Default RPC source used by the sample application.
+    // Change to `RpcSource.TritonOne` or another source for mainnet.
+    val rpcSource: RpcSource = RpcSource.Devnet
     val network: Network = rpcSource.endpoint.network
-    const val solscanApiKey: String = ""
+    // Insert your Solscan API key below.
+    // The sample will start syncing once a valid key is provided.
+    const val solscanApiKey: String = "<YOUR_SOLSCAN_API_KEY>"
     const val walletId = "walletId"
     const val defaultsWords = ""
 }


### PR DESCRIPTION
## Summary
- default RPC source to Devnet
- add instructions in README to change `rpcSource`
- provide placeholder Solscan API key

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685dd087327c8325a53b8e0321d9412c