### PR TITLE
Fix unit test URL scheme

### DIFF
--- a/solanakit/src/test/java/io/horizontalsystems/solanakit/transactions/TransactionManagerFlowTest.kt
+++ b/solanakit/src/test/java/io/horizontalsystems/solanakit/transactions/TransactionManagerFlowTest.kt
@@ -51,7 +51,7 @@ class TransactionManagerFlowTest {
 
         val httpClient = OkHttpClient.Builder().build()
         val config = NetworkingRouterConfig(emptyList(), emptyList())
-        val endpoint = RPCEndpoint.custom(URL("https://localhost"), URL("wss://localhost"), Network.devnet)
+        val endpoint = RPCEndpoint.custom(URL("https://localhost"), URL("http://localhost"), Network.devnet)
         val api = Api(OkHttpNetworkingRouter(endpoint, httpClient, config))
         val tokenAccountManager = TokenAccountManager("11111111111111111111111111111111", api, storage, mainStorage, SolanaFmService())
         val action = Action(api, listOf())


### PR DESCRIPTION
## Summary
- adjust websocket URL in `TransactionManagerFlowTest` to use HTTP scheme so that `java.net.URL` can parse it

## Testing
- `./gradlew :solanakit:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_b_685eef979f5c832588fa60e84daea7c2